### PR TITLE
Fix waterlogged state when replacing blocks

### DIFF
--- a/pages/studio.vue
+++ b/pages/studio.vue
@@ -157,6 +157,13 @@ async function applyTool() {
                     resultNbt.set(key, new NbtString(value));
                   }
                 }
+                if (
+                  propertiesNbt &&
+                  propertiesNbt.has('waterlogged') &&
+                  !resultNbt.has('waterlogged')
+                ) {
+                  resultNbt.set('waterlogged', propertiesNbt.get('waterlogged')!);
+                }
                 blockNbt.set('Properties', resultNbt);
               }
             } else {


### PR DESCRIPTION
## Summary
- ensure block replacement retains the `waterlogged` state

## Testing
- `npm run build` *(fails: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_684f068344cc8326b99645036f2d4a47